### PR TITLE
Adding error array to better error description

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ uses:
 
 ## **Data Types**
 
-### *Error Message Data type*
+### *Error Response*
 
-All error messages in Management Center _MUST_ be of the Error Message data type.
+Data Type to be used when returning errors. 
 
 ### *UUID*
 

--- a/common.raml
+++ b/common.raml
@@ -1,4 +1,4 @@
 #%RAML 1.0 Library
 
-traits: 
+traits:
   common-errors: !include traits/common-errors.raml

--- a/dataTypes/error-message.raml
+++ b/dataTypes/error-message.raml
@@ -1,6 +1,0 @@
-#%RAML 1.0 DataType
-
-properties: 
-  message:
-    type: string
-    required: true

--- a/dataTypes/error-response.raml
+++ b/dataTypes/error-response.raml
@@ -1,0 +1,27 @@
+#%RAML 1.0 DataType
+
+properties:
+  message:
+    description: |
+      Human readable error description.
+    type: string
+    required: true
+  errors:
+    description: |
+      Error list use to describe the set of validations that has failed. Only required in case
+      HTTP error code is not enough to describe the failure case.
+    type: array
+    required: false
+    items:
+      properties:
+        code:
+          description: |
+            Machine error description. Internal code representation for cosumer
+            code error handling.
+          type: string
+          required: true
+        message:
+          description: |
+            Human readable error description.
+          type: string
+          required: true

--- a/examples/bad-rq-response.raml
+++ b/examples/bad-rq-response.raml
@@ -1,0 +1,9 @@
+#%RAML 1.0 NamedExample
+
+value:
+  message: Invalid Request
+  errors:
+    - code: XX005
+      message: Invalid Name Format.
+    - code: XX006
+      message: Reached Maximum number of Resources

--- a/resourceTypes/collection-item.raml
+++ b/resourceTypes/collection-item.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 ResourceType
 
-uses: 
+uses:
   std: ../common.raml
 
 is: [std.common-errors]
@@ -12,7 +12,7 @@ get?:
     {<<resourcePathName|!singularize>>Id}
   responses:
     200:
-      headers: 
+      headers:
         ETag:
           required: false
           description: The current value of the entity tag for the requested variant
@@ -25,37 +25,34 @@ get?:
     404:
       body:
         application/json:
-          type: !include ../dataTypes/error-message.raml
-          example: |
-            {"message": "<<resourcePathName|!singularize>> not found" }
+          type: !include ../dataTypes/error-response.raml
+          example:
+            value:
+              message : <<resourcePathName|!singularize>> not found
 put?:
   body:
     application/json:
       type: <<itemPutType>>
       examples: <<itemPutExamples>>
-  responses: 
+  responses:
     400:
       description: Bad Request.
       body:
         application/json:
-          type: !include ../dataTypes/error-message.raml
-          example: |
-                { "message" : "Your request does not have the correct values"}
+          type: !include ../dataTypes/error-response.raml
+          example: !include ../examples/bad-rq-response.raml
 patch?:
   body:
     application/json:
       type: <<itemPatchType>>
       examples: <<itemPatchExamples>>
-  responses: 
+  responses:
     400:
       description: Bad Request.
       body:
         application/json:
-          type: !include ../dataTypes/error-message.raml
-          example: |
-                { "message" : "Your request does not have the correct values"}
-
+          type: !include ../dataTypes/error-response.raml
+          example: !include ../examples/bad-rq-response.raml
 delete?:
-  responses: 
+  responses:
     204:
-    

--- a/resourceTypes/collection.raml
+++ b/resourceTypes/collection.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0 ResourceType
 
-uses: 
+uses:
   std: ../common.raml
 
 is: [std.common-errors]
@@ -9,7 +9,7 @@ get?:
   description: Get a list of <<resourcePathName>>.
   responses:
     200:
-      headers:         
+      headers:
         ETag:
           required: false
           description: The current value of the entity tag for the requested variant
@@ -22,15 +22,14 @@ get?:
 post?:
   description: |
     Create a new <<resourcePathName|!singularize>>.
-  body: 
+  body:
     application/json:
       type: <<itemCreateRequestType>>
       examples: <<itemCreateRequestExamples>>
-  responses: 
+  responses:
      400:
       description: Bad Request.
       body:
         application/json:
-          type: !include ../dataTypes/error-message.raml
-          example: |
-                { "message" : "Your request does not have the correct values"}
+          type: !include ../dataTypes/error-response.raml
+          example: !include ../examples/bad-rq-response.raml

--- a/securitySchemes/authorization.raml
+++ b/securitySchemes/authorization.raml
@@ -1,5 +1,8 @@
 #%RAML 1.0 SecurityScheme
 
+uses:
+  std: ../common.raml
+
 description: |
   Authorization Security Scheme to be use when integrating with Anypoint Access Management
 type: x-token
@@ -27,15 +30,17 @@ describedBy:
                               error_description="The access token expired"
       body:
         application/json:
-          type: !include ../dataTypes/error-message.raml
-          example: |
-            { "message" : "Invalid Bearer Token" }
+          type: !include ../dataTypes/error-response.raml
+          example:
+            value:
+              message : Invalid Bearer Token
     403:
       description: |
         The Authorization header could determine an authenticated user but has no
         permission to access the resource.
       body:
         application/json:
-          type: !include ../dataTypes/error-message.raml
-          example: |
-            { "message" : "You are not authorized to perform this request"}
+          type: !include ../dataTypes/error-response.raml
+          example:
+            value:
+              message : You are not authorized to perform this request

--- a/standards.raml
+++ b/standards.raml
@@ -10,12 +10,12 @@ traits:
   common-errors: !include traits/common-errors.raml
 
 types:
-  error-message: !include dataTypes/error-message.raml
+  error-response: !include dataTypes/error-response.raml
   uuid: !include dataTypes/UUID.raml
 
 securitySchemes:
   auth-header: !include securitySchemes/authorization.raml
 
-resourceTypes: 
+resourceTypes:
   collection: !include resourceTypes/collection.raml
   collection-item: !include resourceTypes/collection-item.raml

--- a/traits/common-errors.raml
+++ b/traits/common-errors.raml
@@ -1,21 +1,22 @@
 #%RAML 1.0 Trait
 
-responses: 
+responses:
   415:
     body:
       application/json:
-        type: !include ../dataTypes/error-message.raml
-        example: |
-          { "message" : "Not Supported  Content-Type"}
+        type: !include ../dataTypes/error-response.raml
+        example:
+          value:
+            message : Not Supported  Content-Type
   429:
-    headers: 
+    headers:
       Retry-After:
         examples:
           after-seconds: |
             120
     body:
       application/json:
-        type: !include ../dataTypes/error-message.raml
-        example: |
-          { "message" : "Too Many Requests"}
-        
+        type: !include ../dataTypes/error-response.raml
+        example:
+          value:
+            message : Too Many Requests


### PR DESCRIPTION
Added Errors array in the Error Data Type in order to be able to describe request failures in a better way. 

The Rationale behind this change is the *Bad Request Scenario*, in general returning Bad Request header is not enough for client side applications to handle the error. The Message description is not machine readable so we need to provide a more specific code.

Why an array?. Multiple validations cloud have failed in the request.

Why optional?. Not all the error responses require error description. For example Unauthorized.
